### PR TITLE
fix duplicate requests (http://localhost:3000/css/common.css)

### DIFF
--- a/code/web/public/js/service-worker.js
+++ b/code/web/public/js/service-worker.js
@@ -21,7 +21,6 @@ var filesToCache = [
   '/js/bundles/app.js',
   '/css/reset.css',
   '/css/common.css',
-  '/css/common.css',
   '/images/collage.png'
 ];
 


### PR DESCRIPTION
Browser was showing below error :

    Uncaught (in promise) DOMException: Cache.addAll(): duplicate requests (http://localhost:3000/css/common.css)

It was just because in `service-worker.js` file `'/css/common.css'` was written twice to be cached.
<br /> 
<br />
**Related Screenshot :**
<br />
![image](https://user-images.githubusercontent.com/7483415/82119479-8cbb5100-979c-11ea-93a6-2233a03399f6.png)
